### PR TITLE
Fix order of permission switches in ChmodCalculatorGuiTool

### DIFF
--- a/DevToys.ExtensionKit/Tools/Converters/Chmod/ChmodCalculatorGuiTool.cs
+++ b/DevToys.ExtensionKit/Tools/Converters/Chmod/ChmodCalculatorGuiTool.cs
@@ -89,9 +89,9 @@ internal sealed partial class ChmodCalculatorGuiTool : IGuiTool
         // Initialize the 2D array of switches
         PermissionSwitches =
         [
-            [OwnerReadSwitch, GroupReadSwitch, OtherReadSwitch],
-            [OwnerWriteSwitch, GroupWriteSwitch, OtherWriteSwitch],
-            [OwnerExecuteSwitch, GroupExecuteSwitch, OtherExecuteSwitch]
+            [OwnerReadSwitch, OwnerWriteSwitch, OwnerExecuteSwitch],
+            [GroupReadSwitch, GroupWriteSwitch, GroupExecuteSwitch],
+            [OtherReadSwitch, OtherWriteSwitch, OtherExecuteSwitch]
         ];
 
         UpdateChmodResult();


### PR DESCRIPTION
This pull request includes a small but important change to the `ChmodCalculatorGuiTool` class in `DevToys.ExtensionKit/Tools/Converters/Chmod/ChmodCalculatorGuiTool.cs`. The update reorganizes the `PermissionSwitches` 2D array to group switches by permission type (read, write, execute) rather than by user category (owner, group, other).