### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET Test
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release - Nuget
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     tags: 


### PR DESCRIPTION
Potential fix for [https://github.com/yui10/DevToys.ExtensionKit/security/code-scanning/1](https://github.com/yui10/DevToys.ExtensionKit/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` to allow the workflow to read repository contents.
- `packages: write` to allow the workflow to publish packages to NuGet.org.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
